### PR TITLE
Tighten the check for a commonjs environment.

### DIFF
--- a/levenshtein.js
+++ b/levenshtein.js
@@ -196,7 +196,7 @@
     });
   }
   // commonjs
-  else if (typeof module !== "undefined" && module !== null) {
+  else if (typeof module !== "undefined" && module !== null && typeof exports !== "undefined" && module.exports === exports) {
     module.exports = Levenshtein;
   }
   // web worker


### PR DESCRIPTION
Looking only for a top-level `module` that is non-null incorrectly flags e.g. the `module` function [QUnit](http://qunitjs.com) 1.x. This restricts it to checking that both `module` and `exports` exists and that `module.exports === exports`, as is the case in a commonjs environment.