### PR TITLE
Readme: Updated link towards cdn

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ If you are not using any module loader system then the API will then be accessib
 
 **CDN**
 
-The latest version is now also always available at https://npm-cdn.com/pkg/fast-levenshtein/ 
+The latest version is now also always available at https://unpkg.com/fast-levenshtein
 
 ## Examples
 


### PR DESCRIPTION
The previous CDN had an expired certificate, therefore I updated it to unpkg.com