### PR TITLE
Add architecture ppc64le to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
-
+arch:
+  - amd64
+  - ppc64le
 node_js:
   - 8.0
   - 10.0


### PR DESCRIPTION
Add architecture ppc64le to travis buildHi,
I had added ppc64le support on Travis-ci and Its been success added and build. Kindly review and merge same.

Changes done are added ppc64le arch.

The Travis ci build logs can be verified from the link below.
https://travis-ci.com/github/zazzel/fast-levenshtein
Please have a look.

Thank you